### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -26,6 +26,12 @@ class DisplaysController < ApplicationController
   end
 
   def update
+    @display = Display.find(params[:id])
+    if @display.update(display_params)
+      redirect_to display_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -22,6 +22,7 @@ class DisplaysController < ApplicationController
   end
 
   def edit
+    @display = Display.find(params[:id])
   end
 
   def update

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -23,6 +23,10 @@ class DisplaysController < ApplicationController
 
   def edit
     @display = Display.find(params[:id])
+
+      unless @display.user_id == current_user.id
+        redirect_to root_path
+      end
   end
 
   def update

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -1,4 +1,5 @@
 class DisplaysController < ApplicationController
+  before_action :set_display, only: [:edit, :update]
   before_action :authenticate_user!, except: [:index, :show]
   def index
     @displays = Display.includes(:user).order("created_at DESC")
@@ -22,15 +23,12 @@ class DisplaysController < ApplicationController
   end
 
   def edit
-    @display = Display.find(params[:id])
-
       unless @display.user_id == current_user.id
         redirect_to root_path
       end
   end
 
   def update
-    @display = Display.find(params[:id])
     if @display.update(display_params)
       redirect_to display_path
     else
@@ -41,6 +39,10 @@ class DisplaysController < ApplicationController
   private
   def display_params
     params.require(:display).permit(:display_name, :image, :instruction, :genre_id, :area_id, :day_id, :load_id, :status_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_display
+    @display = Display.find(params[:id])
   end
 
 end

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -23,9 +23,7 @@ class DisplaysController < ApplicationController
   end
 
   def edit
-      unless @display.user_id == current_user.id
-        redirect_to root_path
-      end
+    redirect_to root_path unless @display.user_id == current_user.id
   end
 
   def update

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -1,5 +1,6 @@
 class DisplaysController < ApplicationController
   before_action :set_display, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
   before_action :authenticate_user!, except: [:index, :show]
   def index
     @displays = Display.includes(:user).order("created_at DESC")
@@ -22,7 +23,6 @@ class DisplaysController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless @display.user_id == current_user.id
   end
 
   def update
@@ -40,6 +40,10 @@ class DisplaysController < ApplicationController
 
   def set_display
     @display = Display.find(params[:id])
+  end
+
+  def move_to_index
+    edirect_to root_path unless @display.user_id == current_user.id
   end
 
 end

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -1,5 +1,5 @@
 class DisplaysController < ApplicationController
-  before_action :set_display, only: [:edit, :update]
+  before_action :set_display, only: [:show, :edit, :update]
   before_action :authenticate_user!, except: [:index, :show]
   def index
     @displays = Display.includes(:user).order("created_at DESC")
@@ -19,7 +19,6 @@ class DisplaysController < ApplicationController
   end
 
   def show
-    @display = Display.find(params[:id])
   end
 
   def edit

--- a/app/controllers/displays_controller.rb
+++ b/app/controllers/displays_controller.rb
@@ -21,6 +21,12 @@ class DisplaysController < ApplicationController
     @display = Display.find(params[:id])
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   private
   def display_params
     params.require(:display).permit(:display_name, :image, :instruction, :genre_id, :area_id, :day_id, :load_id, :status_id, :price).merge(user_id: current_user.id)

--- a/app/views/displays/edit.html.erb
+++ b/app/views/displays/edit.html.erb
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/displays/edit.html.erb
+++ b/app/views/displays/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @display, url: display_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :display_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :instruction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:genre_id, Genre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:load_id, Load.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/displays/show.html.erb
+++ b/app/views/displays/show.html.erb
@@ -25,7 +25,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @display.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_display_path(@display.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>  

--- a/app/views/displays/show.html.erb
+++ b/app/views/displays/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= @display.user.nickname %>
+      <%= @display.display_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @display.image ,class:"item-box-img" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "displays#index"
-  resources :displays, only: [:new, :create, :show]
+  resources :displays, only: [:new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
 ・商品編集画面表示
 ・ログインの有無、ユーザーの違いによる遷移機能追加
 ※商品購入機能は未実装です

# Why
 商品情報編集機能を実装するため

# プルリクエストへ記載するgyazo
・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://i.gyazo.com/f31c6e779acc307f7c3e99b67bd31fc8.mp4

・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://i.gyazo.com/d78abd33b2025709edbcf062c33a62a5.mp4

・入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://i.gyazo.com/33f43101b52120e55332bdd686f1c0d2.mp4

・何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://i.gyazo.com/44b3454769f1eba5ed475a8dda4e6ed4.mp4

・ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
(techというユーザーがkatoの編集画面に直接遷移しようとしました)
https://i.gyazo.com/835da037836c858ae1ff56cfd24b9d73.mp4

・ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://i.gyazo.com/c9194cc84f0a0ba623fec2805302c8c9.mp4

・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://i.gyazo.com/44cb0cbfb51e6292f67ff4835f2c6f09.mp4